### PR TITLE
Add 'end' event to Asset.

### DIFF
--- a/src/asset.coffee
+++ b/src/asset.coffee
@@ -91,6 +91,9 @@ class Asset extends EventEmitter
         @decoder = new decoder(@demuxer, @format)
         @decoder.on 'data', (buffer) =>
             @emit 'data', buffer
+			
+        @decoder.on 'end', () =>
+            @emit 'end'
             
         @decoder.on 'error', (err) =>
             @emit 'error', err


### PR DESCRIPTION
Especially when 'duration' doesn't always fire, it's very useful to have a notification of when decoding has completed and there will be no more 'data' events. Of course, this requires cooperation from decoders to notify the asset.
