### PR TITLE
Update to allow proper content range requests

### DIFF
--- a/src/sources/browser/http.coffee
+++ b/src/sources/browser/http.coffee
@@ -12,7 +12,7 @@ class AV.HTTPSource extends AV.EventEmitter
         @xhr = new XMLHttpRequest()
         
         @xhr.onload = (event) =>
-            @length = parseInt @xhr.getResponseHeader("Content-Length")                
+            @length = parseInt @xhr.getResponseHeader("Content-Length") - 1               
             @inflight = false
             @loop()
         


### PR DESCRIPTION
When av.httpsource makes a partial content request, it requests the final chunk one byte too long. Example:

0-1000/1000
should actually be
0-999/1000

This causes xmlhttprequest errors in Chrome when getting 1MB chunks of files (Firefox seemed to compensate for the issue). The fix just sets the total file request size one byte less so we do not throw an error and drop the final request chunk in Chrome.

I've only tested this in Chrome and Firefox doing content range requests with FLAC so mileage could possibly vary on other setups (but I doubt it).