### PR TITLE
Add the ability to build Aurora.js, excluding the default codecs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ By itself, Aurora will play LPCM, uLaw and aLaw files in a number of containers.
 by including some of our other decoders such as [FLAC.js](https://github.com/audiocogs/flac.js), 
 [ALAC.js](https://github.com/audiocogs/alac.js), and [MP3.js](https://github.com/devongovett/mp3.js).
 
+If you want to build Aurora without the default codecs, you can use the "browser_slim.coffee" profile:
+
+    importer browser_slim.coffee aurora.js
+
+This can help shave off approx. 30 KB from the joined file, or 20 KB when minified.
+    
 ## License
 
 Aurora.js is released under the MIT license.

--- a/browser_slim.coffee
+++ b/browser_slim.coffee
@@ -1,0 +1,10 @@
+do ->
+    global = this
+    
+    #import "src/aurora_base.coffee"
+    #import "src/sources/browser/http.coffee"
+    #import "src/sources/browser/file.coffee"
+    #import "src/devices/webaudio.coffee"
+    #import "src/devices/mozilla.coffee"
+    
+    global.AV = AV

--- a/src/aurora.coffee
+++ b/src/aurora.coffee
@@ -1,24 +1,4 @@
-AV = {}
-
-#import "core/base.coffee"
-#import "core/buffer.coffee"
-#import "core/bufferlist.coffee"
-#import "core/stream.coffee"
-#import "core/bitstream.coffee"
-#import "core/events.coffee"
-
-#import "sources/buffer.coffee"
-
-#import "demuxer.coffee"
-#import "decoder.coffee"
-#import "queue.coffee"
-#import "device.coffee"
-#import "asset.coffee"
-#import "player.coffee"
-
-#import "filter.coffee"
-#import "filters/volume.coffee"
-#import "filters/balance.coffee"
+#import "aurora_base.coffee"
 
 #import "demuxers/caf.coffee"
 #import "demuxers/m4a.coffee"
@@ -28,4 +8,3 @@ AV = {}
 
 #import "decoders/lpcm.coffee"
 #import "decoders/xlaw.coffee"
-

--- a/src/aurora_base.coffee
+++ b/src/aurora_base.coffee
@@ -1,0 +1,21 @@
+AV = {}
+
+#import "core/base.coffee"
+#import "core/buffer.coffee"
+#import "core/bufferlist.coffee"
+#import "core/stream.coffee"
+#import "core/bitstream.coffee"
+#import "core/events.coffee"
+
+#import "sources/buffer.coffee"
+
+#import "demuxer.coffee"
+#import "decoder.coffee"
+#import "queue.coffee"
+#import "device.coffee"
+#import "asset.coffee"
+#import "player.coffee"
+
+#import "filter.coffee"
+#import "filters/volume.coffee"
+#import "filters/balance.coffee"


### PR DESCRIPTION
This is useful to minimise the download size in the browser, especially when you want to decode only
one particular file format.
