### PR TITLE
Wrap reader.abort() in a trycatch in browser FileSource.pause

### DIFF
--- a/src/sources/browser/file.coffee
+++ b/src/sources/browser/file.coffee
@@ -45,7 +45,9 @@ class AV.FileSource extends AV.EventEmitter
         
     pause: ->
         @active = false
-        @reader?.abort()
+        try
+          @reader?.abort()
+        catch error
         
     reset: ->
         @pause()


### PR DESCRIPTION
Fixes #62.
