### PR TITLE
Changed AV.BufferList to BufferList

### DIFF
--- a/src/sources/buffer.coffee
+++ b/src/sources/buffer.coffee
@@ -5,7 +5,7 @@ AVBuffer = require '../core/buffer'
 class BufferSource extends EventEmitter    
     constructor: (input) ->
         # Now make an AV.BufferList
-        if input instanceof AV.BufferList
+        if input instanceof BufferList
             @list = input
             
         else


### PR DESCRIPTION
AV does not exist in this scope; throws an error in the browser when using `AV.Player.fromBuffer()`
