### PR TITLE
adds header to fix safari stream bug

### DIFF
--- a/src/sources/browser/http.coffee
+++ b/src/sources/browser/http.coffee
@@ -68,6 +68,7 @@ class HTTPSource extends EventEmitter
         @xhr.responseType = "arraybuffer"
 
         endPos = Math.min(@offset + @chunkSize, @length)
+        @xhr.setRequestHeader("If-None-Match", "webkit-no-cache")
         @xhr.setRequestHeader("Range", "bytes=#{@offset}-#{endPos}")
         @xhr.overrideMimeType('text/plain; charset=x-user-defined')
         @xhr.send(null)


### PR DESCRIPTION
When using aurora to stream sound. It appears that safari versions 6 & 7 only receive first chunck of data. It receives all chuncks but ranges are still 0-XXXX.

see https://bugs.webkit.org/show_bug.cgi?id=82672