### PR TITLE
Add length option to HTTPSource constructor

### DIFF
--- a/src/sources/browser/http.coffee
+++ b/src/sources/browser/http.coffee
@@ -2,9 +2,11 @@ EventEmitter = require '../../core/events'
 AVBuffer = require '../../core/buffer'
 
 class HTTPSource extends EventEmitter
-    constructor: (@url) ->
+    constructor: (@url, @opts = {}) ->
         @chunkSize = 1 << 20
         @inflight = false
+        if @opts.length
+            @length = @opts.length
         @reset()
         
     start: ->


### PR DESCRIPTION
If the Content-Length is known at the time of HTTPSource instantiation, 
an HTTP HEAD request may be skipped, reducing playback latency.