### PR TITLE
Add length option to HTTPSource constructor

### DIFF
--- a/src/asset.coffee
+++ b/src/asset.coffee
@@ -31,8 +31,8 @@ class Asset extends EventEmitter
         @source.on 'progress', (@buffered) =>
             @emit 'buffer', @buffered
             
-    @fromURL: (url) ->
-        return new Asset new HTTPSource(url)
+    @fromURL: (url, opts) ->
+        return new Asset new HTTPSource(url, opts)
 
     @fromFile: (file) ->
         return new Asset new FileSource(file)

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -47,8 +47,8 @@ class Player extends EventEmitter
         @asset.on 'error', (error) =>
             @emit 'error', error
                 
-    @fromURL: (url) ->
-        return new Player Asset.fromURL(url)
+    @fromURL: (url, opts) ->
+        return new Player Asset.fromURL(url, opts)
         
     @fromFile: (file) ->
         return new Player Asset.fromFile(file)

--- a/src/sources/browser/http.coffee
+++ b/src/sources/browser/http.coffee
@@ -2,9 +2,11 @@ EventEmitter = require '../../core/events'
 AVBuffer = require '../../core/buffer'
 
 class HTTPSource extends EventEmitter
-    constructor: (@url) ->
+    constructor: (@url, @opts = {}) ->
         @chunkSize = 1 << 20
         @inflight = false
+        if @opts.length
+            @length = @opts.length
         @reset()
         
     start: ->


### PR DESCRIPTION
If the Content-Length is known at the time of HTTPSource instantiation, 
an HTTP HEAD request may be skipped, reducing playback latency.