### PR TITLE
updates speaker version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/audiocogs/aurora.js/issues",
   "optionalDependencies": {
-    "speaker": "~0.0.10"
+    "speaker": "~0.2.5"
   },
   "devDependencies": {
     "coffee-script": ">=1.0",


### PR DESCRIPTION
The version of the optional dependency `speaker` was out of date, I've updated it to prevent ugly failures displaying in the `npm i` log of dependent packages. Tests seem to pass, would be good to verify. It'd also be great to have a CI service running tests.