### PR TITLE
Stopping Error and Music still playing after deletion FIXED, and some extras.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ ehthumbs.db
 Thumbs.db
 node_modules
 /build/
+*.js
+!src/devices/resampler.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "bugs": "https://github.com/audiocogs/aurora.js/issues",
   "optionalDependencies": {
-    "speaker": "~0.2.5"
+    "speaker": "~0.2.6"
   },
   "devDependencies": {
     "coffee-script": ">=1.0",

--- a/src/asset.coffee
+++ b/src/asset.coffee
@@ -150,4 +150,10 @@ class Asset extends EventEmitter
         continue while @decoder.decode() and @active
         @decoder.once 'data', @_decode if @active
         
+    destroy: ->
+        @demuxer?.off()
+        @decoder?.off()
+        @source?.off()
+        @off()
+        
 module.exports = Asset

--- a/src/core/events.coffee
+++ b/src/core/events.coffee
@@ -7,9 +7,15 @@ class EventEmitter extends Base
         @events[event].push(fn)
         
     off: (event, fn) ->
-        return unless @events?[event]
-        index = @events[event].indexOf(fn)
-        @events[event].splice(index, 1) if ~index
+        return unless @events?
+        if @events?[event]
+            if fn?
+                index = @events[event].indexOf(fn)
+                @events[event].splice(index, 1) if ~index
+            else
+                @events[event]
+        else unless event?
+            events = {}
         
     once: (event, fn) ->
         @on event, cb = ->

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -35,7 +35,7 @@ class AudioDevice extends EventEmitter
         
     destroy: ->
         @stop()
-        @device.destroy()
+        @device?.destroy()
         
     seek: (@currentTime) ->
         @_lastTime = @device.getDeviceTime() if @playing

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -159,4 +159,10 @@ class Player extends EventEmitter
         @device.start() if @playing
         @emit 'ready'
         
+    destroy: ->
+        @stop()
+        @device?.off()
+        @asset?.destroy()
+        @off()
+        
 module.exports = Player


### PR DESCRIPTION
Calling AV.Player.stop() after AV.Player.preload() but before AV.Player.play() results in this error:
```Uncaught TypeError: Cannot read property 'destroy' of undefined``` - FIXED
* [/src/device.coffee:38:16](https://github.com/MathijsvVelde/aurora.js/blob/dcb4f73d891726db05c486c2eb31dda2be4ada0f/src/device.coffee#L38)

Music still playing after deleting the AV.Player, AV.Player.asset or AV.Asset object.
Added the ability to destroy the AV.Player, AV.Player.asset or AV.Asset objects
* [/src/asset.coffee:153:5/5:97](https://github.com/MathijsvVelde/aurora.js/blob/dcb4f73d891726db05c486c2eb31dda2be4ada0f/src/asset.coffee#L153-L157)
* [/src/player.coffee:162:5/5:91](https://github.com/MathijsvVelde/aurora.js/blob/dcb4f73d891726db05c486c2eb31dda2be4ada0f/src/player.coffee#L162-L166)

Added the ability to remove all event handlers from specific event or an entire class. (needed for the above)
* [/src/core/events.coffee:10:9/9:276](https://github.com/MathijsvVelde/aurora.js/blob/dcb4f73d891726db05c486c2eb31dda2be4ada0f/src/core/events.coffee#L10-L18)

Updated the Speaker, just in case...