### PR TITLE
Stop the source of loading data

### DIFF
--- a/src/asset.coffee
+++ b/src/asset.coffee
@@ -151,6 +151,7 @@ class Asset extends EventEmitter
         @decoder.once 'data', @_decode if @active
         
     destroy: ->
+        @stop()
         @demuxer?.off()
         @decoder?.off()
         @source?.off()


### PR DESCRIPTION
Stop the source of loading data when the destroy function is called.
For when the track is not fully loaded and you destroy the player or asset
I forgot that in Pull Request #158 