### PR TITLE
fixed application stop after throw an error.

### DIFF
--- a/src/demuxer.coffee
+++ b/src/demuxer.coffee
@@ -15,7 +15,10 @@ class Demuxer extends EventEmitter
         source.on 'data', (chunk) =>
             received = true
             list.append chunk
-            @readChunk chunk
+            try
+              @readChunk chunk
+            catch e
+              @emit 'error', e
             
         source.on 'error', (err) =>
             @emit 'error', err


### PR DESCRIPTION
Some codec modules has error throwing if they faced an error. To avoid application stop after error accour, wrap in `try ... catch`.

Then you can listen to error event, and continue a work. For example, we read metadata, and `readChunk` throw as error

        asset.on('error', function(e) {
          console.log(e); // log an error and continue...

          callback(); // continue
        });

        asset.get('metadata', (metadata) => {
          console.log(metadata);

          callback(); //continue
        });